### PR TITLE
Scroll to the end of the result buffer on code block execution(#15).

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -428,6 +428,7 @@ class KernelConnection(object):
             'append',
             {'characters': text})
         view.set_read_only(True)
+        view.show(view.size())
 
     def _write_phantom(self, content: str):
         file_size = self.get_view().size()

--- a/messages/0.3.5.txt
+++ b/messages/0.3.5.txt
@@ -1,0 +1,7 @@
+Update in 0.3.4
+---------------
+
+  - Scroll to the end of the result buffer on code block execution(#15).
+
+Now we plan to rename and refactor the commands as argued in #4 (working branch is #14).
+If you have any openion about it, feel free to express it in the issue.


### PR DESCRIPTION
Fixed #15, now result view is scrolled to its end when code is executed.