### PR TITLE
Fix requests error handling

### DIFF
--- a/hermes.py
+++ b/hermes.py
@@ -219,6 +219,8 @@ class KernelManager(object):
             url,
             data=data,
             headers=header)
+        if response.status_code != requests.codes.ok:
+            response.raise_for_status()
         return response.json()
 
     @classmethod
@@ -233,6 +235,8 @@ class KernelManager(object):
         response = requests.get(
             url,
             headers=header)
+        if response.status_code != requests.codes.ok:
+            response.raise_for_status()
         return response.json()
 
     @classmethod
@@ -247,6 +251,8 @@ class KernelManager(object):
         response = requests.delete(
             url,
             headers=header)
+        if response.status_code != requests.codes.ok:
+            response.raise_for_status()
         return response.json()
 
 

--- a/messages/0.3.6.txt
+++ b/messages/0.3.6.txt
@@ -2,3 +2,4 @@ Update in 0.3.6
 ---------------
 
   - Fixed code block detection when there are code block(s) selected.
+  - Better error handlings around communicating via Jupyter APIs (related to #19).


### PR DESCRIPTION
Error handling around Jupyter APIs was wrong and couldn't catch error, therefore no warning in the case like  #19 .
This PR fixes it.