### PR TITLE
Feature/inline phantoms

### DIFF
--- a/Hermes.sublime-settings
+++ b/Hermes.sublime-settings
@@ -1,6 +1,7 @@
 {
   "complete": true,  // Whether use Hermes' autocomplete powered by Jupyter kernel.
   "complete_timeout": 0.5, // Timeout to get completion (in seconds).
+  "inline_output": false, // Set to true to show output in current view, like Jupyter
   "connections": [
     // The list of connections.
     // Example of connection setting:

--- a/hermes.py
+++ b/hermes.py
@@ -738,10 +738,10 @@ def _execute_block(view, *, logger=HERMES_LOGGER):
 
     pre_code = []
     for s in view.sel():
-        code, _ = get_block(view, s)
+        code, region = get_block(view, s)
         if code == pre_code:
             continue
-        kernel.execute_code(code)
+        kernel.execute_code(code, region)
         log_info_msg = "Executed code {code} with kernel {kernel_id}".format(
             code=code,
             kernel_id=kernel.kernel_id)

--- a/kernel.py
+++ b/kernel.py
@@ -58,14 +58,18 @@ TEXT_PHANTOM = """<body id="hermes-result">
     .stdout {{ color: gray }}
     .error {{ color: var(--redish) }}
     .other {{ color: var(--yellowish) }}
+    .closebutton {{ text-decoration: none }}
   </style>
+  <a class=closebutton href=hide>×</a>
   {content}
 </body>"""
 
 IMAGE_PHANTOM = """<body id="hermes-image-result">
   <style>
     .image {{ background-color: white }}
+    .closebutton {{ text-decoration: none }}
   </style>
+  <a class=closebutton href=hide>×</a>
   '<img class="image" alt="Out" src="data:image/png;base64,{data}" />
 </body>"""
 
@@ -544,13 +548,14 @@ class KernelConnection(object):
     def _write_inline_html_phantom(self, content: str):
         if self.parent_view:
             region = self.parent_view.sel()[-1]
-            id = HERMES_FIGURE_PHANTOMS
+            id = HERMES_FIGURE_PHANTOMS + datetime.now().isoformat()
             html = TEXT_PHANTOM.format(content=content)
             self.parent_view.add_phantom(
                 id,
                 region,
                 html,
-                sublime.LAYOUT_BLOCK)
+                sublime.LAYOUT_BLOCK,
+                on_navigate=lambda href, id=id: self.parent_view.erase_phantoms(id))
             self._logger.info("Created inline phantom {}".format(html))
         else:
             self._logger.error("Parent view not set, can't create html phantom")
@@ -558,13 +563,14 @@ class KernelConnection(object):
     def _write_inline_image_phantom(self, data: str):
         if self.parent_view:
             region = self.parent_view.sel()[-1]
-            id = HERMES_FIGURE_PHANTOMS
+            id = HERMES_FIGURE_PHANTOMS + datetime.now().isoformat()
             html = IMAGE_PHANTOM.format(data=data)
             self.parent_view.add_phantom(
                 id,
                 region,
                 html,
-                sublime.LAYOUT_BLOCK)
+                sublime.LAYOUT_BLOCK,
+                on_navigate=lambda href, id=id: self.parent_view.erase_phantoms(id))
             self._logger.info("Created inline phantom image")
         else:
             self._logger.error("Parent view not set, can't create phantom image")


### PR DESCRIPTION
Shows Jupyter output as inline phantoms (in addition to the result view)
Both images and text are supported. Text is processed to show DataFrames correctly
There's also a small X button to hide the phantoms